### PR TITLE
bug discovered, private key QR loaded the public key

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
         document.getElementById("privateKey").textContent = privateWif;
         var qr = new QRious({
           element: document.getElementById('privateKeyCanvas'),
-          value: publicKey,
+          value: privateWif,
           size: 150
         });
       })


### PR DESCRIPTION
_to EOS cafe: verify this before you merge this pull request_

**How are users affected?**
Paper wallets that have been generated so far with https://eoscafe.github.io/eos-paper-wallet/ are still valid, except that the QR for the private key is not the private key, it is a duplicate of the public key. Paper wallets generated after this pull request is merged will have both a public key and a private key QR code.